### PR TITLE
Mark KQueue::Native#kevent as blocking with FFI

### DIFF
--- a/lib/rb-kqueue/native.rb
+++ b/lib/rb-kqueue/native.rb
@@ -34,7 +34,7 @@ module KQueue
     ffi_lib FFI::Library::LIBC
 
     attach_function :kqueue, [], :int
-    attach_function :kevent, [:int, :pointer, :int, :pointer, :int, :pointer], :int
+    attach_function :kevent, [:int, :pointer, :int, :pointer, :int, :pointer], :int, :blocking => true
 
     attach_function :open, [:string, :int], :int
     attach_function :close, [:int], :int


### PR DESCRIPTION
kevent is a blocking function and needs to be marked a such with FFI so it will release Ruby's global interpreter lock when calling it.  Without this, calls to KQueue::Queue#run will hang the entire Ruby process, preventing other threads from running as well as preventing SIGINT/SIGTERM from being handled.
