### PR TITLE
Support NetBSD

### DIFF
--- a/lib/rb-kqueue/native.rb
+++ b/lib/rb-kqueue/native.rb
@@ -13,13 +13,39 @@ module KQueue
     #
     # @private
     class KEvent < FFI::Struct
-      layout(
-        :ident,  :uintptr_t,
-        :filter, :int16,
-        :flags,  :uint16,
-        :fflags, :uint32,
-        :data,   :intptr_t,
-        :udata,  :pointer)
+      if FFI::Platform::IS_FREEBSD
+        layout(
+          :ident,  :uintptr_t,
+          :filter, :short,
+          :flags,  :u_short,
+          :fflags, :u_int,
+          :data,   :intptr_t,
+          :udata,  :pointer)
+      elsif FFI::Platform::IS_NETBSD
+        layout(
+          :ident,  :uintptr_t,
+          :filter, :uint32_t,
+          :flags,  :uint32_t,
+          :fflags, :uint32_t,
+          :data,   :int64_t,
+          :udata,  :pointer)
+      elsif FFI::Platform::IS_OPENBSD
+        layout(
+          :ident,  :__uintptr_t,
+          :filter, :short,
+          :flags,  :u_short,
+          :fflags, :u_int,
+          :data,   :quad_t,
+          :udata,  :pointer)
+      else
+        layout(
+          :ident,  :uintptr_t,
+          :filter, :int16,
+          :flags,  :uint16,
+          :fflags, :uint32,
+          :data,   :intptr_t,
+          :udata,  :pointer)
+      end
     end
 
     # The C struct describing a timeout.

--- a/lib/rb-kqueue/native/flags.rb
+++ b/lib/rb-kqueue/native/flags.rb
@@ -6,17 +6,50 @@ module KQueue
     # @private
     module Flags
       # Filters
-      EVFILT_READ = -1
-      EVFILT_WRITE = -2
-      EVFILT_AIO = -3 # Attached to aio requests
-      EVFILT_VNODE = -4 # Attached to vnodes
-      EVFILT_PROC = -5 # Attached to struct proc
-      EVFILT_SIGNAL = -6 # Attached to struct proc
-      EVFILT_TIMER = -7 # Timers
-      EVFILT_MACHPORT = -8 # Mach portsets
-      EVFILT_FS = -9 # Filesystem events
-      EVFILT_USER = -10 # User events
-      EVFILT_SESSION = -11 # Audit session events
+      if FFI::Platform::IS_FREEBSD
+        EVFILT_READ	=	-1
+        EVFILT_WRITE	=	-2
+        EVFILT_AIO	=	-3	# Attached to aio requests
+        EVFILT_VNODE	=	-4	# Attached to vnodes
+        EVFILT_PROC	=	-5	# Attached to struct proc
+        EVFILT_SIGNAL	=	-6	# Attached to struct proc
+        EVFILT_TIMER	=	-7	# Timers
+        EVFILT_PROCDESC	=	-8	# Attached to process descriptors
+        EVFILT_FS	=	-9	# Filesystem events
+        EVFILT_LIO	=	-10	# Attached to lio requests
+        EVFILT_USER	=	-11	# User events
+        EVFILT_SENDFILE	=	-12	# Attached to sendfile requests
+        EVFILT_SYSCOUNT	=	12
+      elsif FFI::Platform::IS_NETBSD
+        EVFILT_READ	=	0
+        EVFILT_WRITE	=	1
+        EVFILT_AIO	=	2	# Attached to aio requests
+        EVFILT_VNODE	=	3	# Attached to vnodes
+        EVFILT_PROC	=	4	# Attached to struct proc
+        EVFILT_SIGNAL	=	5	# Attached to struct proc
+        EVFILT_TIMER	=	6	# Arbitrary timer (in ms)
+        EVFILT_SYSCOUNT	=	7	# Number of filters
+      elsif FFI::Platform::IS_OPENBSD
+        EVFILT_READ	=	-1
+        EVFILT_WRITE	=	-2
+        EVFILT_AIO	=	-3	# Attached to aio requests
+        EVFILT_VNODE	=	-4	# Attached to vnodes
+        EVFILT_PROC	=	-5	# Attached to struct proc
+        EVFILT_SIGNAL	=	-6	# Attached to struct proc
+        EVFILT_TIMER	=	-7	# Timers
+      else
+        EVFILT_READ	=	-1
+        EVFILT_WRITE	=	-2
+        EVFILT_AIO	=	-3	# Attached to aio requests
+        EVFILT_VNODE	=	-4	# Attached to vnodes
+        EVFILT_PROC	=	-5	# Attached to struct proc
+        EVFILT_SIGNAL	=	-6	# Attached to struct proc
+        EVFILT_TIMER	=	-7	# Timers
+        EVFILT_MACHPORT	=	-8	# Mach portsets
+        EVFILT_FS	=	-9	# Filesystem events
+        EVFILT_USER	=	-10	# User events
+        EVFILT_SESSION	=	-11	# Audit session events
+      end
 
 
       # Actions


### PR DESCRIPTION
NetBSD uses different sizes of the members `filter`, `flags` of the structure `kevent`. It also uses different numbering of the `EVFILT_` flags.

I've compared the `event.h` header files of FreeBSD, NetBSD and OpenBSD and changed the files `lib/rb-kqueue/native.rb` and `lib/rb-kqueue/native/flags.rb` to match what I've found there regarding the `kevent` structure and the `EVFILT_` flags.

c.f.

```
http://svnweb.freebsd.org/base/head/sys/sys/event.h?revision=HEAD&view=co
http://cvsweb.netbsd.org/bsdweb.cgi/~checkout~/src/sys/sys/event.h?rev=HEAD&content-type=text/plain
http://www.openbsd.org/cgi-bin/cvsweb/src/sys/sys/event.h?rev=HEAD;content-type=text%2Fplain
```
