### PR TITLE
Fix top level exception on unexpected event

### DIFF
--- a/lib/rb-kqueue/native/flags.rb
+++ b/lib/rb-kqueue/native/flags.rb
@@ -97,6 +97,9 @@ module KQueue
       NOTE_TIMER_NSECONDS = 0x00000004 # data is nanoseconds
       NOTE_TIMER_ABSOLUTE = 0x00000008 # absolute timeout
 
+      # Exception raised when a function fails to find a flag satisfying
+      # its given query.
+      class FlagNotFound < Exception; end
 
       # Converts a list of flags to the bitmask that the C API expects.
       #
@@ -143,6 +146,7 @@ module KQueue
           next unless c =~ re
           return c.to_s.sub("#{prefix}_", "").downcase.to_sym if const_get(c) == flag
         end
+        raise FlagNotFound
       end
     end
   end

--- a/lib/rb-kqueue/queue.rb
+++ b/lib/rb-kqueue/queue.rb
@@ -359,7 +359,13 @@ module KQueue
       res = Native.kevent(@fd, nil, 0, eventlist, size, timeout)
 
       KQueue.handle_error if res < 0
-      (0...res).map {|i| KQueue::Event.new(Native::KEvent.new(eventlist[i]), self)}
+      (0...res).map do |i|
+        begin
+          KQueue::Event.new(Native::KEvent.new(eventlist[i]), self)
+        rescue KQueue::Event::UnexpectedEvent
+          nil
+        end
+      end.compact
     end
   end
 end


### PR DESCRIPTION
I started hitting this issue on FreeBSD 12: https://github.com/guard/listen/issues/475

I seem to be getting kqueue events with a filter of 0. It's not clear to me what the meaning of such an event is. Prior to this change I would see the behaviour in the linked issue. This patch causes these events to be ignored. I suspect this is just masking a bigger issue, but at least this makes the gem usable for me in the meantime.

I tested this by running a jekyll server on FreeBSD 12 with ruby 2.6.