### PR TITLE
Fix wrong number of arguments (given 1, expected 0) (ArgumentError)

### DIFF
--- a/lib/rb-kqueue/watcher/file.rb
+++ b/lib/rb-kqueue/watcher/file.rb
@@ -42,7 +42,7 @@ module KQueue
       end
 
       def self.finalizer(fd, path)
-        lambda do
+        lambda do |id|
           next unless Native.close(fd) < 0
           raise SystemCallError.new(
             "Failed to close file #{path}" +

--- a/lib/rb-kqueue/watcher/file.rb
+++ b/lib/rb-kqueue/watcher/file.rb
@@ -42,7 +42,7 @@ module KQueue
       end
 
       def self.finalizer(fd, path)
-        lambda do |id|
+        lambda do |id=nil|
           next unless Native.close(fd) < 0
           raise SystemCallError.new(
             "Failed to close file #{path}" +


### PR DESCRIPTION
like this
```
Exception in finalizer #<Proc:0x0000000108289a20 ...ruby-3.1.0/gems/rb-kqueue-0.2.7/lib/rb-kqueue/watcher/file.rb:45 (lambda)>
...rb-kqueue-0.2.7/lib/rb-kqueue/watcher/file.rb:45:in `block in finalizer': wrong number of arguments (given 1, expected 0) (ArgumentError)
```

According to ri ObjectSpace.define_finalizer:

```
If aProc is a lambda or method, make sure it can be called with a
single argument.
```

Fixes #17