### PR TITLE
Fix random behaviour on FreeBSD 12 when using Rails with Spring

### DIFF
--- a/lib/rb-kqueue/native.rb
+++ b/lib/rb-kqueue/native.rb
@@ -14,13 +14,23 @@ module KQueue
     # @private
     class KEvent < FFI::Struct
       if FFI::Platform::IS_FREEBSD
-        layout(
+        fields = [
           :ident,  :uintptr_t,
           :filter, :short,
           :flags,  :u_short,
           :fflags, :u_int,
           :data,   :intptr_t,
-          :udata,  :pointer)
+          :udata,  :pointer ]
+
+        # The FFI gem incorrectly determines the freebsd version, by ignoring
+        # the decimal place
+        freebsd_version = RbConfig::CONFIG['host_os'].gsub(/[^\d.]/, '').to_f
+
+        if freebsd_version >= 12.0
+          fields.push(:ext, [ :u_int64_t, 4 ])
+        end
+
+        layout(*fields)
       elsif FFI::Platform::IS_NETBSD
         layout(
           :ident,  :uintptr_t,

--- a/lib/rb-kqueue/native.rb
+++ b/lib/rb-kqueue/native.rb
@@ -14,20 +14,28 @@ module KQueue
     # @private
     class KEvent < FFI::Struct
       if FFI::Platform::IS_FREEBSD
-        fields = [
-          :ident,  :uintptr_t,
-          :filter, :short,
-          :flags,  :u_short,
-          :fflags, :u_int,
-          :data,   :intptr_t,
-          :udata,  :pointer ]
-
         # The FFI gem incorrectly determines the freebsd version, by ignoring
         # the decimal place
         freebsd_version = RbConfig::CONFIG['host_os'].gsub(/[^\d.]/, '').to_f
 
+        fields = [
+          :ident,  :uintptr_t,
+          :filter, :short,
+          :flags,  :u_short,
+          :fflags, :u_int ]
+
         if freebsd_version >= 12.0
-          fields.push(:ext, [ :u_int64_t, 4 ])
+          fields.push(
+            :data,  :int64_t,
+            :udata, :pointer,
+            :ext,   [ :u_int64_t, 4 ])
+        else
+          # FreeBSD 11 has no ext member, and uses intptr_t for
+          # data member
+          fields.push(
+            :data,  :intptr_t,
+            :udata, :pointer
+          )
         end
 
         layout(*fields)


### PR DESCRIPTION
In FreeBSD 12+ when trying to boot Rails using Spring, Rails tries to use rb-kqueue to add a listener to every file in the project as well as everything under `node_modules/` - this can be thousands of files and will randomly die with:

```
/usr/home/pmurray/rb-kqueue/lib/rb-kqueue.rb:27:in `handle_error': Bad address - KQueue failed: There was an error reading or writing the kevent structure. (Errno::EFAULT)
```

I noticed the `kevent` structure had changed with a new member `ext u_int64_t[4]` added to the end of it, this doesn't seem like it should fix an intermittent error... but it seems to? So I think it might actually be a bug in FreeBSD. But anyway, here's a test case without my fix:

```ruby
def run(queue)
  max = 0
  begin
    2_000.times { 
      queue.watch_file('/usr/home/pmurray/somedir', *[:delete, :write, :extend, :attrib, :rename]) { puts "Something happened" }
      max += 1 
    }
  rescue => e
    puts "Got to #{max}"
    raise e
  end

  puts "Completed #{max}"
end

queue = KQueue::Queue.new
run(queue)
```

Returns 

```
Got to 1671
 /usr/home/pmurray/rb-kqueue/lib/rb-kqueue.rb:27:in `handle_error': Bad address - KQueue failed: There was an error reading or writing the kevent structure. (Errno::EFAULT)
```

Repeated runs ended in random number of successful watches each time, from 83 to well into the thousands. It doesn't matter if you're watching the same file or different files (or directories).

With my fix applied, I can repeatedly, successfully, and reliably make it through all 2000 attempts:

```irb(main):054:0> run(queue)
Completed 2000
=> nil
irb(main):055:0> run(queue)
Completed 2000
=> nil
irb(main):056:0> run(queue)
Completed 2000
=> nil
irb(main):057:0> run(queue)
Completed 2000
=> nil
```


